### PR TITLE
Fix `JavadocParagraph`

### DIFF
--- a/src/main/resources/config/maven_checks.xml
+++ b/src/main/resources/config/maven_checks.xml
@@ -179,6 +179,7 @@ under the License.
         <module name="SimplifyBooleanExpression"/>
         <module name="SimplifyBooleanReturn"/>
         <module name="UnusedLocalVariable"/>
+        <module name="JavadocParagraph"/>
 
         <!-- Checks for class design                         -->
         <!-- See https://checkstyle.org/checks/design/index.html   -->


### PR DESCRIPTION
Fix `JavadocParagraph`

depends on:
- https://github.com/openrewrite/rewrite-static-analysis/issues/545

enabler for
- https://checkstyle.org/checks/javadoc/javadocparagraph.html
- https://github.com/apache/maven/pull/2302

ref
- https://github.com/apache/maven-shared-resources/pull/73