### PR TITLE
Fix `IllegalCatch`

### DIFF
--- a/src/main/resources/config/maven_checks_nocodestyle.xml
+++ b/src/main/resources/config/maven_checks_nocodestyle.xml
@@ -120,6 +120,7 @@ under the License.
             <property name="ignoreConstructorParameter" value="true"/>
         </module>
         <module name="IllegalInstantiation"/>
+        <module name="IllegalCatch"/>
         <module name="InnerAssignment"/>
         <module name="MissingSwitchDefault"/>
         <module name="OneStatementPerLine"/>


### PR DESCRIPTION
Fix `JavadocParagraph`

depends on:
- https://github.com/openrewrite/rewrite-static-analysis/issues/545


> we shouldn't be catching raw exceptions here; probably fix that first

https://github.com/apache/maven/pull/2306#discussion_r2081558306

ref
- https://checkstyle.sourceforge.io/checks/coding/illegalcatch.html
- https://github.com/apache/maven-shared-resources/pull/72